### PR TITLE
feature: Merge Document and JsonApiResponse

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -55,15 +55,17 @@ pub struct JsonApiResponse {
     pub data: PrimaryData,
     pub included: Option<Resources>,
     pub links: Option<Links>,
+    pub meta: Option<Meta>,
+    pub errors: Option<JsonApiErrors>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct ErrorSource {
     pub pointer: Option<String>,
     pub parameter: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct JsonApiError {
     pub id: String,
     pub links: Links,
@@ -100,21 +102,17 @@ impl Pagination {
 
 // Spec says at least one of data, errors, meta
 // data and errors must not co-exist
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Document {
-    pub data: Option<PrimaryData>,
-    pub errors: Option<JsonApiErrors>,
-    pub meta: Option<Meta>,
-}
-
-impl Document {
-    pub fn has_errors(&self) -> bool {
+impl JsonApiResponse {
+    fn has_errors(&self) -> bool {
         !self.errors.is_none()
     }
-    pub fn has_data(&self) -> bool {
-        !self.data.is_none()
+    fn has_data(&self) -> bool {
+        match self.data {
+            PrimaryData::None => false,
+            _ => true,
+        }
     }
-    pub fn has_meta(&self) -> bool {
+    fn has_meta(&self) -> bool {
         !self.meta.is_none()
     }
     pub fn is_valid(&self) -> bool {

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -43,22 +43,20 @@ fn it_works() {
 
     assert_eq!(deserialized.id, resource.id);
 
-    let document = Document {
-        data: None,
+    let jsonapiresponse = JsonApiResponse {
+        data: PrimaryData::None,
         errors: None,
         meta: None,
+        included: None,
+        links: None,
     };
 
-    assert_eq!(document.has_data(), false);
-    assert_eq!(document.has_errors(), false);
-    assert_eq!(document.has_meta(), false);
-
-    assert_eq!(document.is_valid(), false);
+    assert_eq!(jsonapiresponse.is_valid(), false);
 
 }
 
 #[test]
-fn document_can_be_valid() {
+fn jsonapi_response_can_be_valid() {
     let resource = Resource {
         _type: format!("test"),
         id: format!("123"),
@@ -69,29 +67,35 @@ fn document_can_be_valid() {
 
     let errors = JsonApiErrors::new();
 
-    let invalid_document = Document {
-        data: None,
+    let invalid_document = JsonApiResponse {
+        data: PrimaryData::None,
         errors: None,
         meta: None,
+        included: None,
+        links: None,
     };
 
     assert_eq!(invalid_document.is_valid(), false);
 
-    let document_with_data = Document {
-        data: Some(PrimaryData::Single(resource)),
+    let jsonapi_response_with_data = JsonApiResponse {
+        data: PrimaryData::Single(resource),
         errors: None,
         meta: None,
+        included: None,
+        links: None,
     };
 
-    assert_eq!(document_with_data.is_valid(), true);
+    assert_eq!(jsonapi_response_with_data.is_valid(), true);
 
-    let document_with_errors = Document {
-        data: None,
+    let jsonapi_response_with_errors = JsonApiResponse {
+        data: PrimaryData::None,
         errors: Some(errors),
         meta: None,
+        included: None,
+        links: None,
     };
 
-    assert_eq!(document_with_errors.is_valid(), true);
+    assert_eq!(jsonapi_response_with_errors.is_valid(), true);
 
 }
 


### PR DESCRIPTION
The Document struct is obsolete and this removes it and merges its
functionality with JsonApiResponse