### PR TITLE
bugfix: Not to include data and errors in a same document

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -71,10 +71,12 @@ pub enum IdentifierData {
 /// The specification refers to this as a top-level `document`
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct JsonApiDocument {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<PrimaryData>,
     pub included: Option<Resources>,
     pub links: Option<Links>,
     pub meta: Option<Meta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<JsonApiErrors>,
     pub jsonapi: Option<JsonApiInfo>,
 }

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -40,6 +40,40 @@ fn it_works() {
 }
 
 #[test]
+fn the_members_data_and_errors_must_not_coexist() {
+    use serde_json::Value;
+
+    let jsonapidocument = JsonApiDocument {
+        data: Some(PrimaryData::None),
+        errors: None,
+        meta: None,
+        included: None,
+        links: None,
+        jsonapi: None,
+    };
+
+    let string = serde_json::to_string(&jsonapidocument).unwrap();
+    let json: Value = serde_json::from_str(&string).unwrap();
+    assert_eq!(json.get("data").unwrap().is_null(), true);
+    assert_eq!(json.get("errors"), None);
+
+    let errors = JsonApiErrors::new();
+    let jsonapi_document_with_errors = JsonApiDocument {
+        data: None,
+        errors: Some(errors),
+        meta: None,
+        included: None,
+        links: None,
+        jsonapi: None,
+    };
+
+    let string = serde_json::to_string(&jsonapi_document_with_errors).unwrap();
+    let json: Value = serde_json::from_str(&string).unwrap();
+    assert_eq!(json.get("data"), None);
+    assert_eq!(json.get("errors").unwrap().is_array(), true);
+}
+
+#[test]
 fn jsonapi_document_can_be_valid() {
     let _ = env_logger::init();
     let resource = Resource {


### PR DESCRIPTION
http://jsonapi.org/format/#document-top-level
> The members data and errors MUST NOT coexist in the same
> document.