### PR TITLE
feature: Box the PrimaryData::Single variant

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -55,7 +55,7 @@ pub struct Relationship {
 #[serde(untagged)]
 pub enum PrimaryData {
     None,
-    Single(Resource),
+    Single(Box<Resource>),
     Multiple(Resources),
 }
 

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -88,7 +88,7 @@ fn jsonapi_document_can_be_valid() {
     let errors = JsonApiErrors::new();
 
     let jsonapi_document_with_data = JsonApiDocument {
-        data: Some(PrimaryData::Single(resource)),
+        data: Some(PrimaryData::Single(Box::new(resource))),
         errors: None,
         meta: None,
         included: None,
@@ -165,7 +165,7 @@ fn jsonapi_document_invalid_errors() {
     }
 
     let mixed_errors_and_data_document = JsonApiDocument {
-        data: Some(PrimaryData::Single(resource)),
+        data: Some(PrimaryData::Single(Box::new(resource))),
         errors: Some(errors),
         meta: None,
         included: None,


### PR DESCRIPTION
Enum size is bounded by the largest variant. The Single(Resource) variant is disproportionately large.