### PR TITLE
Use and serialize sparse structs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -32,14 +32,17 @@ pub struct ResourceIdentifier {
 }
 
 /// JSON-API Resource
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Resource {
     #[serde(rename = "type")]
     pub _type: String,
     pub id: JsonApiId,
     pub attributes: ResourceAttributes,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub relationships: Option<Relationships>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
 }
 
@@ -47,6 +50,7 @@ pub struct Resource {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Relationship {
     pub data: IdentifierData,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
 }
 
@@ -69,20 +73,24 @@ pub enum IdentifierData {
 }
 
 /// The specification refers to this as a top-level `document`
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct JsonApiDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<PrimaryData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub included: Option<Resources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<JsonApiErrors>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub jsonapi: Option<JsonApiInfo>,
 }
 
 /// Error location
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ErrorSource {
     pub pointer: Option<String>,
     pub parameter: Option<String>,
@@ -90,15 +98,23 @@ pub struct ErrorSource {
 
 /// JSON-API Error
 /// All fields are optional
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct JsonApiError {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<ErrorSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
 }
 
@@ -174,10 +190,7 @@ impl JsonApiDocument {
     /// let doc = JsonApiDocument {
     ///     data: Some(PrimaryData::None),
     ///     errors: Some(JsonApiErrors::new()),
-    ///     meta: None,
-    ///     included: None,
-    ///     links: None,
-    ///     jsonapi: None,
+    ///     ..Default::default()
     /// };
     ///
     /// assert_eq!(doc.is_valid(), false);
@@ -198,10 +211,7 @@ impl JsonApiDocument {
     /// let doc = JsonApiDocument {
     ///     data: Some(PrimaryData::None),
     ///     errors: Some(JsonApiErrors::new()),
-    ///     meta: None,
-    ///     included: None,
-    ///     links: None,
-    ///     jsonapi: None,
+    ///     ..Default::default()
     /// };
     ///
     /// match doc.validate() {

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ pub struct PageParams {
 }
 
 /// JSON-API Query parameters
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct Query {
     pub _type: String,
     pub include: Option<Vec<String>>,
@@ -133,9 +133,7 @@ impl Query {
                 error!("Query::from_params : Can't parse : {:?}", err);
                 Query {
                     _type: "none".into(),
-                    include: None,
-                    fields: None,
-                    page: None,
+                    ..Default::default()
                 }
             }
         }


### PR DESCRIPTION
Hi,
I noticed we're generating 'dense' structs for errors, resources and documents.
For example, we generate:
{"data": {...}, "meta": null, "included": null, "links": null, "jsonapi": null }
Instead of:
{"data":{...}}

This causes issues with the json_api_client ruby gem, and probably a number of other clients, which look for keys to exist before they start processing, but then error out because they found a null value instead of an object.

I looked at the spec and the jsonapi github repo trying to figure out which library was wrong (client or server), and although the json api spec does not explicitly say to set missing keys to null instead of omitting them altogether, there are a number of reasons to think using sparse structures is correct:

- The examples in the jsonapi.org website are sparse.
- The spec may not have explicitly favored sparse structs to avoid being over-explicit (and thus hard to read, a preference briefly mentioned https://github.com/json-api/json-api/issues/101)
- The spec is explicit in other cases where a 'null' shall be used, like in the primary data or links.

I've also derived Default in a number of structures to help with sparse initialization.

cheers!
