### PR TITLE
Update and relax versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ categories = []
 license = "MIT"
 
 [dependencies]
-serde = "1.0.12"
-serde_json = "1.0.3"
-serde_derive = "1.0.12"
+serde = "^1.0.21"
+serde_json = "^1.0.6"
+serde_derive = "^1.0.21"
 queryst = "1"
 log = "0.3"
-error-chain = "0.11.0"
+error-chain = "^0.11.0"
 
 [dev-dependencies]
 env_logger = "0.3"


### PR DESCRIPTION
Using strict locked versions like '1.0.12' leads to block updating dependencies and may cause compiler errors due to using different `serde` crate versions.