### PR TITLE
Use an empty HashMap if attributes is not supplied

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -40,6 +40,7 @@ pub struct Resource {
     #[serde(rename = "type")]
     pub _type: String,
     pub id: JsonApiId,
+    #[serde(default)]
     pub attributes: ResourceAttributes,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relationships: Option<Relationships>,

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -518,3 +518,15 @@ fn it_omits_empty_error_keys() {
     assert_eq!(serde_json::to_string(&doc).unwrap(),
         r#"{"errors":[{"id":"error_id"}]}"#);
 }
+
+#[test]
+fn it_allows_for_optional_attributes() {
+    let _ = env_logger::init();
+    let serialized = r#"{
+            "data" : {
+                "id" :"1", "type" : "post", "relationships" : {}, "links" : {}
+            }
+        }"#;
+    let data: Result<JsonApiDocument, serde_json::Error> = serde_json::from_str(serialized);
+    assert_eq!(data.is_ok(), true);
+}


### PR DESCRIPTION
Fixes https://github.com/michiel/jsonapi-rust/issues/30

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/michiel/jsonapi-rust/31)
<!-- Reviewable:end -->
