### PR TITLE
make Relationship data an Option<IdentifierData>

### DIFF
--- a/data/resource_004.json
+++ b/data/resource_004.json
@@ -1,0 +1,15 @@
+{
+  "type": "articles",
+  "id": "1",
+  "attributes": {
+    "title": "Rails is Omakase"
+  },
+  "relationships": {
+    "author": {
+      "links": {
+        "self": "/articles/1/relationships/author",
+        "related": "/articles/1/author"
+      }
+    }
+  }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -53,7 +53,8 @@ pub struct Resource {
 /// Relationship with another object
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Relationship {
-    pub data: IdentifierData,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<IdentifierData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Links>,
 }
@@ -419,17 +420,19 @@ impl FromStr for Resource {
 impl Relationship {
     pub fn as_id(&self) -> std::result::Result<Option<&JsonApiId>, RelationshipAssumptionError> {
         match self.data {
-            IdentifierData::None => Ok(None),
-            IdentifierData::Multiple(_) => Err(RelationshipAssumptionError::RelationshipIsAList),
-            IdentifierData::Single(ref data) => Ok(Some(&data.id)),
+            Some(IdentifierData::None) => Ok(None),
+            Some(IdentifierData::Multiple(_)) => Err(RelationshipAssumptionError::RelationshipIsAList),
+            Some(IdentifierData::Single(ref data)) => Ok(Some(&data.id)),
+            None => Ok(None),
         }
     }
 
     pub fn as_ids(&self) -> std::result::Result<Option<JsonApiIds>, RelationshipAssumptionError> {
         match self.data {
-            IdentifierData::None => Ok(None),
-            IdentifierData::Single(_) => Err(RelationshipAssumptionError::RelationshipIsNotAList),
-            IdentifierData::Multiple(ref data) => Ok(Some(data.iter().map(|x| &x.id).collect())),
+            Some(IdentifierData::None) => Ok(None),
+            Some(IdentifierData::Single(_)) => Err(RelationshipAssumptionError::RelationshipIsNotAList),
+            Some(IdentifierData::Multiple(ref data)) => Ok(Some(data.iter().map(|x| &x.id).collect())),
+            None => Ok(None),
         }
     }
 }

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -364,7 +364,7 @@ fn can_deserialize_jsonapi_example_resource_003() {
 
 #[test]
 fn can_deserialize_jsonapi_example_resource_004() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
     let s = ::read_json_file("data/resource_004.json");
     let data: Result<Resource, serde_json::Error> = serde_json::from_str(&s);
     assert!(data.is_ok());

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -353,6 +353,14 @@ fn can_deserialize_jsonapi_example_resource_003() {
 }
 
 #[test]
+fn can_deserialize_jsonapi_example_resource_004() {
+    let _ = env_logger::init();
+    let s = ::read_json_file("data/resource_004.json");
+    let data: Result<Resource, serde_json::Error> = serde_json::from_str(&s);
+    assert!(data.is_ok());
+}
+
+#[test]
 fn can_deserialize_jsonapi_example_compound_document() {
     let _ = env_logger::init();
     let s = ::read_json_file("data/compound_document.json");


### PR DESCRIPTION
A valid JSON API response may not include a `data` attribute in the relationships. I've added an additional `data/resource_004.json` and test case.

This may help me in resolving some of the problems I am experiencing with #35.