### PR TITLE
bug: stack overflow error with JsonApiModel::resource_to_attrs

### DIFF
--- a/data/author_tolkien.json
+++ b/data/author_tolkien.json
@@ -1,0 +1,284 @@
+{
+  "data": {
+    "id": "1",
+    "type": "authors",
+    "attributes": {
+      "name": "J. R. R. Tolkien"
+    },
+    "relationships": {
+      "books": {
+        "data": [
+          {
+            "id": "1",
+            "type": "books"
+          },
+          {
+            "id": "2",
+            "type": "books"
+          },
+          {
+            "id": "3",
+            "type": "books"
+          }
+        ]
+      }
+    }
+  },
+  "included": [
+    {
+      "id": "1",
+      "type": "books",
+      "attributes": {
+        "title": "The Fellowship of the Ring"
+      },
+      "relationships": {
+        "chapters": {
+          "data": [
+            {
+              "id": "1",
+              "type": "chapters"
+            },
+            {
+              "id": "2",
+              "type": "chapters"
+            },
+            {
+              "id": "3",
+              "type": "chapters"
+            }
+          ]
+        },
+        "first_chapter": {
+          "data": {
+            "id": "1",
+            "type": "chapters"
+          }
+        },
+        "author": {
+          "data": {
+            "id": "1",
+            "type": "authors"
+          }
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "books",
+      "attributes": {
+        "title": "The Two Towers"
+      },
+      "relationships": {
+        "chapters": {
+          "data": [
+            {
+              "id": "23",
+              "type": "chapters"
+            },
+            {
+              "id": "24",
+              "type": "chapters"
+            },
+            {
+              "id": "25",
+              "type": "chapters"
+            }
+          ]
+        },
+        "first_chapter": {
+          "data": {
+            "id": "23",
+            "type": "chapters"
+          }
+        },
+        "author": {
+          "data": {
+            "id": "1",
+            "type": "authors"
+          }
+        }
+      }
+    },
+    {
+      "id": "3",
+      "type": "books",
+      "attributes": {
+        "title": "Return of the King"
+      },
+      "relationships": {
+        "chapters": {
+          "data": [
+            {
+              "id": "44",
+              "type": "chapters"
+            },
+            {
+              "id": "45",
+              "type": "chapters"
+            },
+            {
+              "id": "46",
+              "type": "chapters"
+            }
+          ]
+        },
+        "first_chapter": {
+          "data": {
+            "id": "44",
+            "type": "chapters"
+          }
+        },
+        "author": {
+          "data": {
+            "id": "1",
+            "type": "authors"
+          }
+        }
+      }
+    },
+    {
+      "id": "1",
+      "type": "chapters",
+      "attributes": {
+        "title": "A Long-expected Party",
+        "ordering": 1
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "1",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "2",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Shadow of the Past",
+        "ordering": 2
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "1",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "3",
+      "type": "chapters",
+      "attributes": {
+        "title": "Three is Company",
+        "ordering": 3
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "1",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "23",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Departure of Boromir",
+        "ordering": 1
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "2",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "24",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Riders of Rohan",
+        "ordering": 2
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "2",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "25",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Uruk-hai",
+        "ordering": 3
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "2",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "44",
+      "type": "chapters",
+      "attributes": {
+        "title": "Minas Tirith",
+        "ordering": 1
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "3",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "45",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Passing of the Grey Company",
+        "ordering": 2
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "3",
+            "type": "books"
+          }
+        }
+      }
+    },
+    {
+      "id": "46",
+      "type": "chapters",
+      "attributes": {
+        "title": "The Muster of Rohan",
+        "ordering": 3
+      },
+      "relationships": {
+        "book": {
+          "data": {
+            "id": "3",
+            "type": "books"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -282,18 +282,3 @@ macro_rules! jsonapi_model {
         }
     );
 }
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Dog {
-    id: String,
-    name: String,
-    age: i32,
-    main_flea: Flea,
-    fleas: Vec<Flea>,
-}
-jsonapi_model!(Dog; "dog"; has one main_flea; has many fleas);
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Flea {
-    id: String,
-    name: String,
-}
-jsonapi_model!(Flea; "flea");

--- a/tests/model_test.rs
+++ b/tests/model_test.rs
@@ -3,85 +3,113 @@
 extern crate serde_json;
 use jsonapi::model::*;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Dog {
-    id: String,
-    name: String,
-    age: i32,
-    main_flea: Flea,
-    fleas: Vec<Flea>,
-}
-jsonapi_model!(Dog; "dog"; has one main_flea; has many fleas);
+mod helper;
+use helper::read_json_file;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct Flea {
+struct Author {
     id: String,
     name: String,
+    books: Vec<Book>,
 }
-jsonapi_model!(Flea; "flea");
+jsonapi_model!(Author; "author"; has many books);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Book {
+    id: String,
+    title: String,
+    first_chapter: Chapter,
+    chapters: Vec<Chapter>
+}
+jsonapi_model!(Book; "book"; has one first_chapter; has many chapters);
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Chapter {
+    id: String,
+    title: String,
+    ordering: i32,
+}
+jsonapi_model!(Chapter; "chapter");
 
 #[test]
-fn to_jsonapi_document_and_back(){
-    let dog = Dog{
+fn to_jsonapi_document_and_back() {
+    let book = Book {
         id: "1".into(),
-        name: "fido".into(),
-        age: 2,
-        main_flea: Flea{id: "1".into(), name: "general flea".into() },
-        fleas: vec![
-            Flea{id: "2".into(), name: "rick".into()},
-            Flea{id: "3".into(), name: "morty".into()}
+        title: "The Fellowship of the Ring".into(),
+        first_chapter: Chapter { id: "1".into(), title: "A Long-expected Party".into(), ordering: 1 },
+        chapters: vec![
+            Chapter { id: "1".into(), title: "A Long-expected Party".into(), ordering: 1 },
+            Chapter { id: "2".into(), title: "The Shadow of the Past".into(), ordering: 2 },
+            Chapter { id: "3".into(), title: "Three is Company".into(), ordering: 3 }
         ],
     };
-    let doc = dog.to_jsonapi_document();
-    let json = serde_json::to_string(&doc).unwrap();
-    println!("JSON IS:");
-    let dog_doc: JsonApiDocument = serde_json::from_str(&json)
-        .expect("Dog JsonApiDocument should be created from the dog json");;
-    let dog_again = Dog::from_jsonapi_document(&dog_doc)
-        .expect("Dog should be generated from the dog_doc");
 
-    assert_eq!(dog, dog_again);
+    let doc = book.to_jsonapi_document();
+    let json = serde_json::to_string(&doc).unwrap();
+
+    let book_doc: JsonApiDocument = serde_json::from_str(&json)
+        .expect("Book JsonApiDocument should be created from the book json");
+    let book_again = Book::from_jsonapi_document(&book_doc)
+        .expect("Book should be generated from the book_doc");
+
+    assert_eq!(book, book_again);
 }
 
 #[test]
 fn numeric_id() {
     #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct NumericFlea {
+    struct NumericChapter {
         id: i32,
-        name: String,
+        title: String,
     }
-    jsonapi_model!(NumericFlea; "numeric_flea");
+    jsonapi_model!(NumericChapter; "numeric_chapter");
 
-    let flea = NumericFlea {
-        id: 2,
-        name: "rick".into(),
+    let chapter = NumericChapter {
+        id: 24,
+        title: "The Riders of Rohan".into(),
     };
-    let (res, _) = flea.to_jsonapi_resource();
-    assert_eq!(res.id, "2".to_string());
-    let doc = flea.to_jsonapi_document();
+
+    let (res, _) = chapter.to_jsonapi_resource();
+    assert_eq!(res.id, "24".to_string());
+
+    let doc = chapter.to_jsonapi_document();
     assert!(doc.is_valid());
     assert_eq!(doc.data, Some(PrimaryData::Single(Box::new(res))));
+
     let json = serde_json::to_string(&doc).unwrap();
     let _num_doc: JsonApiDocument = serde_json::from_str(&json)
-        .expect("NumericFlea JsonApiDocument should be created from the flea json");
+        .expect("NumericChapter JsonApiDocument should be created from the chapter json");
 }
 
 #[test]
 fn test_vec_to_jsonapi_document() {
-    let fleas = vec![
-        Flea {
-            id: "2".into(),
-            name: "rick".into(),
+    let chapters = vec![
+        Chapter {
+            id: "45".into(),
+            title: "The Passing of the Grey Company".into(),
+            ordering: 2,
         },
-        Flea {
-            id: "3".into(),
-            name: "morty".into(),
+        Chapter {
+            id: "46".into(),
+            title: "The Muster of Rohan".into(),
+            ordering: 3,
         },
     ];
-    let doc = vec_to_jsonapi_document(fleas);
+
+    let doc = vec_to_jsonapi_document(chapters);
     assert!(doc.is_valid());
 }
 
 #[test]
-fn from_jsonapi_document_and_back(){
+fn from_jsonapi_document_and_back() {
+    let json = ::read_json_file("data/author_tolkien.json");
+
+    let author_doc: JsonApiDocument = serde_json::from_str(&json)
+        .expect("Author JsonApiDocument should be created from the author json");
+    let author = Author::from_jsonapi_document(&author_doc)
+        .expect("Author should be generated from the author_doc");
+
+    let doc_again = author.to_jsonapi_document();
+
+    assert_eq!(author_doc, doc_again);
 }


### PR DESCRIPTION
Replace `Dog` and `Flea` with `Author`, `Book`, `Chapter` to expose bug with `JsonApiModel::resource_to_attrs` and fatal runtime error: stack overflow.

Note this pull-request will break CI until a solution to resolve the error is committed.

I've changed the `test/model_test.rs` to expose the issue with `JsonApiModel::resource_to_attrs`.

This was discovered while trying to troubleshoot #35.