### PR TITLE
Fix cargo/crates.io Travis CI badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ error-chain = "^0.12.0"
 env_logger = "0.6"
 
 [badges]
-travis-ci = { repository = "https://travis-ci.org/michiel/jsonapi-rust/", branch = "master" }
+travis-ci = { repository = "michiel/jsonapi-rust", branch = "master" }


### PR DESCRIPTION
It was previously linking to:

https://travis-ci.org/https://travis-ci.org/michiel/jsonapi-rust/