### PR TITLE
:sparkles: Enable support for "maybe has many

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,26 @@
+use model::JsonApiModel;
+
+/// Trait which allows a `has many` relationship to be optional.
+pub trait JsonApiArray<M> {
+    fn get_models(&self) -> &[M];
+    fn get_models_mut(&mut self) -> &mut [M];
+}
+
+impl<M: JsonApiModel> JsonApiArray<M> for Vec<M> {
+    fn get_models(&self) -> &[M] { self }
+    fn get_models_mut(&mut self) -> &mut [M] { self }
+}
+
+impl<M: JsonApiModel> JsonApiArray<M> for Option<Vec<M>> {
+    fn get_models(&self) -> &[M] {
+        self.as_ref()
+            .map(|v| v.as_slice())
+            .unwrap_or(&[][..])
+    }
+
+    fn get_models_mut(&mut self) -> &mut [M] {
+        self.as_mut()
+            .map(|v| v.as_mut_slice())
+            .unwrap_or(&mut [][..])
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate log;
 extern crate error_chain;
 
 pub mod api;
+pub mod array;
 pub mod query;
 pub mod model;
 pub mod errors;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
 pub use std::collections::HashMap;
 pub use api::*;
+use array::JsonApiArray;
 use errors::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, to_value, Value, Map};
@@ -252,7 +253,7 @@ macro_rules! jsonapi_model {
 
                 Some(FIELDS)
             }
-            
+
             fn build_relationships(&self) -> Option<Relationships> {
                 let mut relationships = HashMap::new();
                 $(
@@ -261,18 +262,22 @@ macro_rules! jsonapi_model {
                     );
                 )*
                 $(
-                    relationships.insert(stringify!($has_many).into(),
-                        Self::build_has_many(&self.$has_many)
+                    relationships.insert(
+                        stringify!($has_many).into(),
+                        {
+                            let values = &self.$has_many.get_models();
+                            Self::build_has_many(values)
+                        }
                     );
                 )*
                 Some(relationships)
             }
-            
+
             fn build_included(&self) -> Option<Resources> {
                 let mut included:Resources = vec![];
                 $( included.append(&mut self.$has_one.to_resources()); )*
                 $(
-                    for model in &self.$has_many {
+                    for model in self.$has_many.get_models() {
                         included.append(&mut model.to_resources());
                     }
                 )*

--- a/tests/model_test.rs
+++ b/tests/model_test.rs
@@ -3,6 +3,7 @@ extern crate jsonapi;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+use jsonapi::array::JsonApiArray;
 use jsonapi::model::*;
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Allows an `Option<Vec<M>>` to be used as a "has many" resource.


Closes #56 