### PR TITLE
chore: Split params parsing to reduce complexity

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -57,7 +57,7 @@ fn ok_params_fields(o:&Value) -> HashMap<String, Vec<String>> {
                 }
             }
         } else {
-            error!("Query::from_params : No fields found in {:?}", x);
+            warn!("Query::from_params : No fields found in {:?}", x);
         }
     }
 
@@ -99,7 +99,7 @@ fn ok_params_filter(o:&Value) -> Option<HashMap<String, Vec<String>>> {
                 }
                 Some(tmp_filter)
             } else {
-                error!("Query::from_params : No filter found in {:?}", x);
+                warn!("Query::from_params : No filter found in {:?}", x);
                 None
             }
         }
@@ -211,7 +211,7 @@ impl Query {
                 ok_params(o)
             }
             Err(err) => {
-                error!("Query::from_params : Can't parse : {:?}", err);
+                warn!("Query::from_params : Can't parse : {:?}", err);
                 Query {
                     _type: "none".into(),
                     ..Default::default()

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
 use queryst::parse;
 use std::collections::HashMap;
+use serde_json::value::Value;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct PageParams {
@@ -16,6 +17,173 @@ pub struct Query {
     pub page: Option<PageParams>,
     pub sort: Option<Vec<String>>,
     pub filter: Option<HashMap<String, Vec<String>>>
+}
+
+//
+// Helper functions to break down the cyclomatic complexity of parameter parsing
+//
+
+fn ok_params_include(o:&Value) -> Option<Vec<String>> {
+    match o.pointer("/include") {
+        None => None,
+        Some(inc) => {
+            match inc.as_str() {
+                None => None,
+                Some(include_str) => {
+                    let arr: Vec<String> =
+                        include_str.split(',').map(|s| s.to_string()).collect();
+                    Some(arr)
+                }
+            }
+        }
+    }
+}
+
+fn ok_params_fields(o:&Value) -> HashMap<String, Vec<String>> {
+    let mut fields = HashMap::<String, Vec<String>>::new();
+
+    if let Some(x) = o.pointer("/fields") {
+        if x.is_object() {
+            if let Some(obj) = x.as_object() {
+                for (key, value) in obj.iter() {
+                    let arr: Vec<String> = match value.as_str() {
+                        Some(string) => {
+                            string.split(',').map(|s| s.to_string()).collect()
+                        }
+                        None => Vec::<String>::new(),
+                    };
+                    fields.insert(key.to_string(), arr);
+
+                }
+            }
+        } else {
+            error!("Query::from_params : No fields found in {:?}", x);
+        }
+    }
+
+    fields
+}
+
+fn ok_params_sort(o:&Value) -> Option<Vec<String>> {
+    match o.pointer("/sort") {
+        None => None,
+        Some(sort) => {
+            match sort.as_str() {
+                None => None,
+                Some(sort_str) => {
+                    let arr: Vec<String> =
+                        sort_str.split(',').map(|s| s.to_string()).collect();
+                    Some(arr)
+                }
+            }
+        }
+    }
+}
+
+fn ok_params_filter(o:&Value) -> Option<HashMap<String, Vec<String>>> {
+    match o.pointer("/filter") {
+        None => None,
+        Some(x) => {
+            if x.is_object() {
+                let mut tmp_filter = HashMap::<String, Vec<String>>::new();
+                if let Some(obj) = x.as_object() {
+                    for (key, value) in obj.iter() {
+                        let arr: Vec<String> = match value.as_str() {
+                            Some(string) => {
+                                string.split(',').map(|s| s.to_string()).collect()
+                            }
+                            None => Vec::<String>::new(),
+                        };
+                        tmp_filter.insert(key.to_string(), arr);
+                    }
+                }
+                Some(tmp_filter)
+            } else {
+                error!("Query::from_params : No filter found in {:?}", x);
+                None
+            }
+        }
+    }
+}
+
+fn ok_params_page(o:&Value) -> PageParams {
+    PageParams {
+        number: match o.pointer("/page/number") {
+            None => {
+                warn!(
+                    "Query::from_params : No page/number found in {:?}, setting \
+                                   default 0",
+                                   o
+                );
+                0
+            }
+            Some(num) => {
+                if num.is_string() {
+                    match num.as_str().map(str::parse::<i64>) {
+                        Some(y) => y.unwrap_or(0),
+                        None => {
+                            warn!(
+                                "Query::from_params : page/number found in {:?}, \
+                                               not able not able to parse it - setting default 0",
+                                               o
+                            );
+                            0
+                        }
+                    }
+                } else {
+                    warn!(
+                        "Query::from_params : page/number found in {:?}, but it is \
+                                       not an expected type - setting default 0",
+                                       o
+                    );
+                    0
+                }
+            }
+        },
+        size: match o.pointer("/page/size") {
+            None => {
+                warn!(
+                    "Query::from_params : No page/size found in {:?}, setting \
+                                   default 0",
+                                   o
+                );
+                0
+            }
+            Some(num) => {
+                if num.is_string() {
+                    match num.as_str().map(str::parse::<i64>) {
+                        Some(y) => y.unwrap_or(0),
+                        None => {
+                            warn!(
+                                "Query::from_params : page/size found in {:?}, \
+                                               not able not able to parse it - setting default 0",
+                                               o
+                            );
+                            0
+                        }
+                    }
+                } else {
+                    warn!(
+                        "Query::from_params : page/size found in {:?}, but it is \
+                                       not an expected type - setting default 0",
+                                       o
+                    );
+                    0
+                }
+            }
+        },
+    }
+}
+
+fn ok_params(o:Value) -> Query {
+    Query {
+        _type: "none".into(),
+        include : ok_params_include(&o),
+        fields: Some(ok_params_fields(&o)),
+        page: Some(ok_params_page(&o)),
+        sort: ok_params_sort(&o),
+        filter: ok_params_filter(&o),
+    }
 }
 
 /// JSON-API Query parameters
@@ -40,154 +208,7 @@ impl Query {
 
         match parse(params) {
             Ok(o) => {
-                let include = match o.pointer("/include") {
-                    None => None,
-                    Some(inc) => {
-                        match inc.as_str() {
-                            None => None,
-                            Some(include_str) => {
-                                let arr: Vec<String> =
-                                    include_str.split(',').map(|s| s.to_string()).collect();
-                                Some(arr)
-                            }
-                        }
-                    }
-                };
-
-                let mut fields = HashMap::<String, Vec<String>>::new();
-
-                if let Some(x) = o.pointer("/fields") {
-                    if x.is_object() {
-                        if let Some(obj) = x.as_object() {
-                            for (key, value) in obj.iter() {
-                                let arr: Vec<String> = match value.as_str() {
-                                    Some(string) => {
-                                        string.split(',').map(|s| s.to_string()).collect()
-                                    }
-                                    None => Vec::<String>::new(),
-                                };
-                                fields.insert(key.to_string(), arr);
-
-                            }
-                        }
-                    } else {
-                        error!("Query::from_params : No fields found in {:?}", x);
-                    }
-                }
-
-                let sort = match o.pointer("/sort") {
-                    None => None,
-                    Some(sort) => {
-                        match sort.as_str() {
-                            None => None,
-                            Some(sort_str) => {
-                                let arr: Vec<String> =
-                                    sort_str.split(',').map(|s| s.to_string()).collect();
-                                Some(arr)
-                            }
-                        }
-                    }
-                };
-
-                let mut filter = match o.pointer("/filter") {
-                    None => None,
-                    Some(x) => {
-                        if x.is_object() {
-                            let mut tmp_filter = HashMap::<String, Vec<String>>::new();
-                            if let Some(obj) = x.as_object() {
-                                for (key, value) in obj.iter() {
-                                    let arr: Vec<String> = match value.as_str() {
-                                        Some(string) => {
-                                            string.split(',').map(|s| s.to_string()).collect()
-                                        }
-                                        None => Vec::<String>::new(),
-                                    };
-                                    tmp_filter.insert(key.to_string(), arr);
-                                }
-                            }
-                            Some(tmp_filter)
-                        } else {
-                            error!("Query::from_params : No filter found in {:?}", x);
-                            None
-                        }
-                    }
-                };
-
-                let page = PageParams {
-                    number: match o.pointer("/page/number") {
-                        None => {
-                            warn!(
-                                "Query::from_params : No page/number found in {:?}, setting \
-                                   default 0",
-                                o
-                            );
-                            0
-                        }
-                        Some(num) => {
-                            if num.is_string() {
-                                match num.as_str().map(str::parse::<i64>) {
-                                    Some(y) => y.unwrap_or(0),
-                                    None => {
-                                        warn!(
-                                            "Query::from_params : page/number found in {:?}, \
-                                               not able not able to parse it - setting default 0",
-                                            o
-                                        );
-                                        0
-                                    }
-                                }
-                            } else {
-                                warn!(
-                                    "Query::from_params : page/number found in {:?}, but it is \
-                                       not an expected type - setting default 0",
-                                    o
-                                );
-                                0
-                            }
-                        }
-                    },
-                    size: match o.pointer("/page/size") {
-                        None => {
-                            warn!(
-                                "Query::from_params : No page/size found in {:?}, setting \
-                                   default 0",
-                                o
-                            );
-                            0
-                        }
-                        Some(num) => {
-                            if num.is_string() {
-                                match num.as_str().map(str::parse::<i64>) {
-                                    Some(y) => y.unwrap_or(0),
-                                    None => {
-                                        warn!(
-                                            "Query::from_params : page/size found in {:?}, \
-                                               not able not able to parse it - setting default 0",
-                                            o
-                                        );
-                                        0
-                                    }
-                                }
-                            } else {
-                                warn!(
-                                    "Query::from_params : page/size found in {:?}, but it is \
-                                       not an expected type - setting default 0",
-                                    o
-                                );
-                                0
-                            }
-                        }
-                    },
-                };
-
-                Query {
-                    _type: "none".into(),
-                    include,
-                    fields: Some(fields),
-                    page: Some(page),
-                    sort,
-                    filter,
-                }
+                ok_params(o)
             }
             Err(err) => {
                 error!("Query::from_params : Can't parse : {:?}", err);

--- a/tests/query_test.rs
+++ b/tests/query_test.rs
@@ -91,7 +91,7 @@ fn can_parse() {
 }
 
 #[test]
-fn can_parse_and_provide_defaults_for_missing_values() {
+fn can_parse_and_provide_defaults_for_partial_fields() {
     let _ = env_logger::try_init();
     let query = Query::from_params("");
 
@@ -121,6 +121,111 @@ fn can_parse_and_provide_defaults_for_missing_values() {
     match query.filter {
         None => assert!(true),
         Some(_) => assert!(false),
+    }
+}
+
+#[test]
+fn can_parse_and_handle_missing_fields_values() {
+    let _ = env_logger::try_init();
+
+    let query = Query::from_params("fields=");
+    match query.fields {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+
+    let query = Query::from_params("fields=key");
+    match query.fields {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+
+    let query = Query::from_params("fields=[key]");
+    match query.fields {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+
+    let query = Query::from_params("fields[key]");
+    match query.fields {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+
+    let query = Query::from_params("fields[key]=");
+    match query.fields {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+}
+
+#[test]
+fn can_parse_and_handle_missing_filter_values() {
+    let _ = env_logger::try_init();
+
+    let query = Query::from_params("filter=");
+    match query.filter {
+        None => assert!(true),
+        Some(_) => assert!(false),
+    }
+
+    let query = Query::from_params("filter=key");
+    match query.filter {
+        None => assert!(true),
+        Some(_) => assert!(false),
+    }
+
+    let query = Query::from_params("filter=[key]");
+    match query.filter {
+        None => assert!(true),
+        Some(_) => assert!(false),
+    }
+
+    let query = Query::from_params("filter[key]");
+    match query.filter {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+
+    let query = Query::from_params("filter[key]=");
+    match query.filter {
+        None => assert!(false),
+        Some(_) => assert!(true),
+    }
+}
+
+#[test]
+fn can_parse_and_handle_missing_page_values() {
+    let _ = env_logger::try_init();
+
+    let query = Query::from_params("page=&");
+
+    match query.page {
+        None => assert!(false),
+        Some(pageparams) => {
+            assert_eq!(pageparams.number, 0);
+            assert_eq!(pageparams.size, 0);
+        }
+    }
+
+    let query = Query::from_params("page[number]=&page[size]=");
+
+    match query.page {
+        None => assert!(false),
+        Some(pageparams) => {
+            assert_eq!(pageparams.number, 0);
+            assert_eq!(pageparams.size, 0);
+        }
+    }
+
+    let query = Query::from_params("page[number]=/&page[size]=/");
+
+    match query.page {
+        None => assert!(false),
+        Some(pageparams) => {
+            assert_eq!(pageparams.number, 0);
+            assert_eq!(pageparams.size, 0);
+        }
     }
 }
 


### PR DESCRIPTION
Break up parameter parsing into helper functions to reduce cyclomatic
complexity.

Signed-off-by: Michiel Kalkman <michiel@nosuchtype.com>