### PR TITLE
Don't suppress errors of serde_json

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,7 @@
 error_chain!{
+    foreign_links {
+        SerdeJson(serde_json::Error);
+    }
     errors {
         ResourceToModelError(t: String) {
             description("Error converting Resource to Model")

--- a/src/model.rs
+++ b/src/model.rs
@@ -181,7 +181,7 @@ where
 
     #[doc(hidden)]
     fn from_serializable<S: Serialize>(s: S) -> Result<Self> {
-        from_value(to_value(s).unwrap()).chain_err(|| "Error casting via serde_json")
+        from_value(to_value(s)?).map_err(Error::from)
     }
 }
 


### PR DESCRIPTION
This PR discloses original `serde_json::Error`.
It's hard to debug large models if errors are suppressed. 