### PR TITLE
ci: Remove codecov from travis-ci build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,31 +6,6 @@ rust:
 matrix:
   allow_failures:
   - rust: nightly
-before_install:
-- sudo apt-get update
-addons:
-  apt:
-    packages:
-    - libcurl4-openssl-dev
-    - libelf-dev
-    - libdw-dev
-    - cmake
-    - gcc
-    - binutils-dev
-after_success: |
-  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-  tar xzf master.tar.gz &&
-  cd kcov-master &&
-  mkdir build &&
-  cd build &&
-  cmake .. &&
-  make &&
-  sudo make install &&
-  cd ../.. &&
-  rm -rf kcov-master &&
-  for file in `ls target/debug/*_*-* | grep -v \.d$`; do mkdir -p "target/cov/$(basename $file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
-  bash <(curl -s https://codecov.io/bash) &&
-  echo "Uploaded code coverage"
 deploy:
   provider: cargo
   condition: $TRAVIS_RUST_VERSION = stable


### PR DESCRIPTION
This removes codecov from the travis plan. This will also require removing the webhook at https://github.com/michiel/jsonapi-rust/settings/hooks
