### PR TITLE
doc: Update documentation throughout repository with examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ Cargo.lock
 *.racertmp
 src/*.bk
 tests/*.bk
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # jsonapi-rust
 
 [![Build Status](https://travis-ci.org/michiel/jsonapi-rust.svg?branch=master)](https://travis-ci.org/michiel/jsonapi-rust)
-[![codecov](https://codecov.io/gh/michiel/jsonapi-rust/branch/master/graph/badge.svg)](https://codecov.io/gh/michiel/jsonapi-rust)
 [![Crates.io Status](http://meritbadge.herokuapp.com/jsonapi)](https://crates.io/crates/jsonapi)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/michiel/jsonapi-rust/master/LICENSE)
 [![Documentation](https://docs.rs/jsonapi/badge.svg)](https://docs.rs/jsonapi)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,5 @@
+//! Defines custom types and structs primarily that composite the JSON:API
+//! document
 use serde_json;
 use std::collections::HashMap;
 use crate::errors::*;
@@ -123,7 +125,8 @@ pub struct JsonApiError {
     pub meta: Option<Meta>,
 }
 
-/// Optional `JsonApiDocument` payload identifying the JSON-API version the server implements
+/// Optional `JsonApiDocument` payload identifying the JSON-API version the
+/// server implements
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct JsonApiInfo {
     pub version: Option<String>,

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,3 +1,4 @@
+//! Defines trait and implementations that allow a `has many` relationship to be optional
 use crate::model::JsonApiModel;
 
 /// Trait which allows a `has many` relationship to be optional.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,115 @@
 #![doc(html_root_url = "https://docs.rs/jsonapi/")]
 
 //! This is documentation for the `jsonapi` crate.
-//! The crate is meant to be used for serializing, deserializing and validating JSON-API requests and responses.
+//! The crate is meant to be used for serializing, deserializing and validating
+//! [JSON:API] requests and responses.
+//!
+//! [JSON:API]: https://jsonapi.org/
+//! [serde]: https://serde.rs
+//! [JsonApiDocument]: api/struct.JsonApiDocument.html
+//! [Resource]: api/struct.Resource.html
+//! [jsonapi_model]: macro.jsonapi_model.html
+//!
+//! ## Examples
+//!
+//! ### Basic Usage with Macro
+//!
+//! Using the [`jsonapi_model!`][jsonapi_model] macro a struct can be converted
+//! into a [`JsonApiDocument`][JsonApiDocument] or [`Resource`][Resource]. It is
+//! required that the struct have an `id` property whose type is `String`. The
+//! second argument in the [`jsonapi_model!`][jsonapi_model] marco defines the
+//! `type` member as required by the [JSON:API] specification
+//!
+//! ```rust
+//! #[macro_use] extern crate serde_derive;
+//! #[macro_use] extern crate jsonapi;
+//! use jsonapi::api::*;
+//! use jsonapi::model::*;
+//!
+//! #[derive(Debug, PartialEq, Serialize, Deserialize)]
+//! struct Flea {
+//!     id: String,
+//!     name: String,
+//! };
+//!
+//! jsonapi_model!(Flea; "flea");
+//!
+//! let example_flea = Flea {
+//!     id: "123".into(),
+//!     name: "Mr.Flea".into(),
+//! };
+//!
+//! // Convert into a `JsonApiDocument`
+//! let doc = example_flea.to_jsonapi_document();
+//! assert!(doc.is_valid());
+//!
+//! // Convert into a `Resource`
+//! let resource = example_flea.to_jsonapi_resource();
+//! ```
+//!
+//! ### Deserializing a JSONAPI Document
+//!
+//! Deserialize a JSONAPI document using [serde] by explicitly declaring the
+//! variable type in `Result`
+//!
+//! ```text
+//! let serialized = r#"
+//! {
+//!   "data": [{
+//!     "type": "articles",
+//!     "id": "1",
+//!     "attributes": {
+//!       "title": "JSON:API paints my bikeshed!",
+//!       "body": "The shortest article. Ever."
+//!     },
+//!     "relationships": {
+//!       "author": {
+//!         "data": {"id": "42", "type": "people"}
+//!       }
+//!     }
+//!   }],
+//!   "included": [
+//!     {
+//!       "type": "people",
+//!       "id": "42",
+//!       "attributes": {
+//!         "name": "John"
+//!       }
+//!     }
+//!   ]
+//! }"#;
+//! let data: Result<Resource, serde_json::Error> = serde_json::from_str(&serialized);
+//! assert_eq!(data.is_ok(), true);
+//! ```
+//!
+//! Or parse the `String` directly using the
+//! [Resource::from_str](api/struct.Resource.html) trait implementation
+//!
+//! ```text
+//! let data = Resource::from_str(&serialized);
+//! assert_eq!(data.is_ok(), true);
+//! ```
+//!
+//!
+//! ## Testing
+//!
+//! Run the tests:
+//!
+//! ```text
+//! cargo test
+//! ```
+//!
+//! Run tests with more verbose output:
+//!
+//! ```text
+//! RUST_BACKTRACE=1 cargo test -- --nocapture
+//! ```
+//!
+//! Run tests whenever files are modified using `cargo watch`:
+//!
+//! ```text
+//! RUST_BACKTRACE=1 cargo watch "test -- --nocapture"
+//! ```
 //!
 
 extern crate serde;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,11 +1,17 @@
+//! Defines the `JsonApiModel` trait. This is primarily used in conjunction with
+//! the [`jsonapi_model!`](../macro.jsonapi_model.html) macro to allow arbitrary
+//! structs which implement `Deserialize` to be converted to/from a
+//! [`JsonApiDocument`](../api/struct.JsonApiDocument.html) or
+//! [`Resource`](../api/struct.Resource.html)
 pub use std::collections::HashMap;
 pub use crate::api::*;
 use crate::errors::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_value, to_value, Value, Map};
 
-/// A trait for any struct that can be converted from/into a Resource.
-/// The only requirement is that your struct has an 'id: String' field.
+/// A trait for any struct that can be converted from/into a
+/// [`Resource`](api/struct.Resource.tml). The only requirement is that your
+/// struct has an `id: String` field.
 /// You shouldn't be implementing JsonApiModel manually, look at the
 /// `jsonapi_model!` macro instead.
 pub trait JsonApiModel: Serialize
@@ -192,6 +198,9 @@ where
     }
 }
 
+/// Converts a `vec!` of structs into
+/// [`Resources`](../api/type.Resources.html)
+///
 pub fn vec_to_jsonapi_resources<T: JsonApiModel>(
     objects: Vec<T>,
 ) -> (Resources, Option<Resources>) {
@@ -214,6 +223,36 @@ pub fn vec_to_jsonapi_resources<T: JsonApiModel>(
     (resources, opt_included)
 }
 
+/// Converts a `vec!` of structs into a
+/// [`JsonApiDocument`](../api/struct.JsonApiDocument.html)
+///
+/// ```rust
+/// #[macro_use] extern crate serde_derive;
+/// #[macro_use] extern crate jsonapi;
+/// use jsonapi::api::*;
+/// use jsonapi::model::*;
+///
+/// #[derive(Debug, PartialEq, Serialize, Deserialize)]
+/// struct Flea {
+///     id: String,
+///     name: String,
+/// }
+///
+/// jsonapi_model!(Flea; "flea");
+///
+/// let fleas = vec![
+///     Flea {
+///         id: "2".into(),
+///         name: "rick".into(),
+///     },
+///     Flea {
+///         id: "3".into(),
+///         name: "morty".into(),
+///     },
+/// ];
+/// let doc = vec_to_jsonapi_document(fleas);
+/// assert!(doc.is_valid());
+/// ```
 pub fn vec_to_jsonapi_document<T: JsonApiModel>(objects: Vec<T>) -> JsonApiDocument {
     let (resources, included) = vec_to_jsonapi_resources(objects);
     JsonApiDocument {
@@ -245,6 +284,9 @@ impl<M: JsonApiModel> JsonApiModel for Box<M> {
     }
 }
 
+/// When applied this macro implements the
+/// [`JsonApiModel`](model/trait.JsonApiModel.html) trait for the provided type
+///
 #[macro_export]
 macro_rules! jsonapi_model {
     ($model:ty; $type:expr) => (


### PR DESCRIPTION
Primary objective of this commit is to create some top-level documentation
in `src/lib.rs` to provide a variety of examples of how to use the
content of this crate.

This commit also includes some documentation for each of the modules to
provide a more clear explanation of the contents of those modules and
how to use them.