### PR TITLE
test: Add test to demonstrate `PartialEq`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -36,7 +36,9 @@ pub struct ResourceIdentifier {
     pub id: JsonApiId,
 }
 
-/// JSON-API Resource
+/// Representation of a JSON:API resource. This is a struct that contains
+/// attributes that map to the JSON:API specification of `id`, `type`,
+/// `attributes`, `relationships`, `links`, and `meta`
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Resource {
     #[serde(rename = "type")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,10 @@
 //! assert_eq!(data.is_ok(), true);
 //! ```
 //!
+//! [`JsonApiDocument`][JsonApiDocument] implements `PartialEq` which allows two
+//! documents to be compared for equality. If two documents possess the **same
+//! contents** the ordering of the attributes and fields within the JSONAPI
+//! document are irrelevant and their equality will be `true`.
 //!
 //! ## Testing
 //!

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,6 +29,8 @@ where
     #[doc(hidden)]
     fn build_included(&self) -> Option<Resources>;
 
+    /// Create an instance of the struct from a
+    /// [`Resource`](../api/struct.Resource.html)
     fn from_jsonapi_resource(resource: &Resource, included: &Option<Resources>)
         -> Result<Self>
     {
@@ -36,6 +38,11 @@ where
         Self::from_serializable(Self::resource_to_attrs(resource, included))
     }
 
+    /// Create a single resource object or collection of resource
+    /// objects directly from a
+    /// [`JsonApiDocument`](../api/struct.JsonApiDocument.html). This method
+    /// will parse the document (the `data` and `included` resources) in an
+    /// attempt to instantiate the calling struct.
     fn from_jsonapi_document(doc: &JsonApiDocument) -> Result<Self> {
         match doc.data.as_ref() {
             Some(primary_data) => {
@@ -57,6 +64,8 @@ where
         }
     }
 
+    /// Converts the instance of the struct into a
+    /// [`Resource`](../api/struct.Resource.html)
     fn to_jsonapi_resource(&self) -> (Resource, Option<Resources>) {
         if let Value::Object(mut attrs) = to_value(self).unwrap() {
             let _ = attrs.remove("id");
@@ -75,6 +84,8 @@ where
     }
 
 
+    /// Converts the struct into a complete
+    /// [`JsonApiDocument`](../api/struct.JsonApiDocument.html)
     fn to_jsonapi_document(&self) -> JsonApiDocument {
         let (resource, included) = self.to_jsonapi_resource();
         JsonApiDocument {
@@ -141,6 +152,10 @@ where
         flattened
     }
 
+    /// When passed a `ResourceIdentifier` (which contains a `type` and `id`)
+    /// this will iterate through the collection provided `haystack` in an
+    /// attempt to find and return the `Resource` whose `type` and `id`
+    /// attributes match
     #[doc(hidden)]
     fn lookup<'a>(needle: &ResourceIdentifier, haystack: &'a [Resource])
         -> Option<&'a Resource>
@@ -153,6 +168,10 @@ where
         None
     }
 
+    /// Return a [`ResourceAttributes`](../api/struct.ResourceAttributes.html)
+    /// object that contains the attributes in this `resource`. This will be
+    /// called recursively for each `relationship` on the resource in an attempt
+    /// to satisfy the properties for the calling struct.
     #[doc(hidden)]
     fn resource_to_attrs(resource: &Resource, included: &Option<Resources>)
         -> ResourceAttributes

--- a/tests/api_test.rs
+++ b/tests/api_test.rs
@@ -552,3 +552,84 @@ fn it_allows_for_optional_attributes() {
     let data: Result<JsonApiDocument, serde_json::Error> = serde_json::from_str(serialized);
     assert_eq!(data.is_ok(), true);
 }
+
+#[test]
+fn it_validates_partialeq_when_compariing_documents() {
+    let _ = env_logger::try_init();
+    let document1 = r#"
+        {
+            "data": {
+              "type": "posts",
+              "id": "1",
+              "attributes": {
+                "title": "Rails is Omakase"
+              },
+              "relationships": {
+                "author": {
+                  "links": {
+                    "self": "/posts/1/relationships/author",
+                    "related": "/posts/1/author"
+                  },
+                  "data": {
+                      "type": "people",
+                      "id": "9"
+                  }
+                },
+                "tags": {
+                  "links": {
+                    "self": "/posts/1/relationships/tags",
+                    "related": "/posts/1/tags"
+                  },
+                  "data": {
+                      "type": "tags",
+                      "id": "99"
+                  }
+                }
+              },
+              "links": {
+                "self": "http://example.com/posts/1"
+              }
+            }
+        }"#;
+
+    let document2 = r#"
+        {
+            "data": {
+              "relationships": {
+                "tags": {
+                  "data": {
+                      "type": "tags",
+                      "id": "99"
+                  },
+                  "links": {
+                    "self": "/posts/1/relationships/tags",
+                    "related": "/posts/1/tags"
+                  }
+                },
+                "author": {
+                  "links": {
+                    "self": "/posts/1/relationships/author",
+                    "related": "/posts/1/author"
+                  },
+                  "data": {
+                      "type": "people",
+                      "id": "9"
+                  }
+                }
+              },
+              "links": {
+                "self": "http://example.com/posts/1"
+              },
+              "attributes": {
+                "title": "Rails is Omakase"
+              },
+              "type": "posts",
+              "id": "1"
+            }
+        }"#;
+    let doc1: Result<JsonApiDocument, serde_json::Error> = serde_json::from_str(document1);
+    let doc2: Result<JsonApiDocument, serde_json::Error> = serde_json::from_str(document2);
+    assert_eq!(doc1.is_ok(), true);
+    assert_eq!(doc2.is_ok(), true);
+    assert!(doc1.unwrap() == doc2.unwrap());
+}


### PR DESCRIPTION
Adds a test to demonstrate `PartialEq` when comparing two parsed
`JsonApiDocument` objects. Useful to demonstrate that ordering of
attributes / keys within the JSON:API document are irrelevant when
comparing two similar documents.

Adds additional docs to various functions for better understanding of
this crate's implementation