### PR TITLE
Improve document validation with more intuitive enum and struct use

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -216,17 +216,6 @@ impl JsonApiDocument {
     /// The spec dictates that the document must have least one of `data`, `errors` or `meta`.
     /// Of these, `data` and `errors` must not co-exist.
     /// The optional field `included` may only be present if the `data` field is present too.
-    ///
-    /// ```
-    /// use jsonapi::api::{JsonApiDocument, PrimaryData, JsonApiErrors};
-    /// let doc = JsonApiDocument {
-    ///     data: Some(PrimaryData::None),
-    ///     errors: Some(JsonApiErrors::new()),
-    ///     ..Default::default()
-    /// };
-    ///
-    /// assert_eq!(doc.is_valid(), false);
-    /// ```
     pub fn is_valid(&self) -> bool {
         self.validate().is_none()
     }
@@ -235,19 +224,36 @@ impl JsonApiDocument {
     /// `DocumentValidationError`
     ///
     /// ```
-    /// use jsonapi::api::{JsonApiDocument, PrimaryData, JsonApiErrors, DocumentValidationError};
+    /// // Simulate an error where `included` has data but `data` does not
+    /// use jsonapi::api::*;
+    /// use std::str::FromStr;
     ///
-    /// let doc = JsonApiDocument {
-    ///     data: Some(PrimaryData::None),
-    ///     errors: Some(JsonApiErrors::new()),
+    /// let serialized = r#"{
+    ///   "id":"1",
+    ///   "type":"post",
+    ///   "attributes":{
+    ///     "title": "Rails is Omakase",
+    ///     "likes": 250
+    ///   },
+    ///   "relationships":{},
+    ///   "links" :{}
+    /// }"#;
+    ///
+    /// let resource = Resource::from_str(&serialized);
+    ///
+    /// let data = DocumentData {
+    ///     data: None,
+    ///     included: Some(vec![resource.unwrap()]),
     ///     ..Default::default()
     /// };
+    ///
+    /// let doc = JsonApiDocument::Data(data);
     ///
     /// match doc.validate() {
     ///   Some(errors) => {
     ///     assert!(
     ///       errors.contains(
-    ///         &DocumentValidationError::DataWithErrors
+    ///         &DocumentValidationError::IncludedWithoutData
     ///       )
     ///     )
     ///   }
@@ -256,7 +262,6 @@ impl JsonApiDocument {
     /// ```
     pub fn validate(&self) -> Option<Vec<DocumentValidationError>> {
         let mut errors = Vec::<DocumentValidationError>::new();
-        println!("{:#?}", self);
 
         match self {
             JsonApiDocument::Error(_x) => None,

--- a/src/api.rs
+++ b/src/api.rs
@@ -81,8 +81,7 @@ pub enum IdentifierData {
     Multiple(ResourceIdentifiers),
 }
 
-/// A struct that defines an error state for a document
-/// Per the v1.0 spec a document may not contain `errors` and `data`
+/// A struct that defines an error state for a JSON:API document
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct DocumentError {
     pub errors: JsonApiErrors,
@@ -94,7 +93,7 @@ pub struct DocumentError {
     pub jsonapi: Option<JsonApiInfo>,
 }
 
-/// A struct that defines the valid state when the document does not contain errors
+/// A struct that defines properties for a JSON:API document that contains no errors
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct DocumentData {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,9 +108,9 @@ pub struct DocumentData {
     pub jsonapi: Option<JsonApiInfo>,
 }
 
-/// Use an enum to create the primitive types of JSONAPI documents. Errors and data cannot mutually
-/// co-exist. Rely on Rust's type system to handle this validation instead of testing attributes in
-/// the JsonApiDocument
+/// An enum that defines the possible composition of a JSON:API document - one which contains `error` or
+/// `data` - but not both.  Rely on Rust's type system to handle this basic validation instead of
+/// running validators on parsed documents
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum JsonApiDocument {
@@ -126,8 +125,7 @@ pub struct ErrorSource {
     pub parameter: Option<String>,
 }
 
-/// JSON-API Error
-/// All fields are optional
+/// Retpresentation of a JSON:API error (all fields are optional)
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct JsonApiError {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,7 +209,7 @@ impl DocumentData {
 /// An "error" document can be valid, just as a "data" document can be valid
 impl JsonApiDocument {
     /// This function returns `false` if the `JsonApiDocument` contains any violations of the
-    /// specification. See `DocumentValidationError`
+    /// specification. See [`DocumentValidationError`](enum.DocumentValidationError.html)
     ///
     /// The spec dictates that the document must have least one of `data`, `errors` or `meta`.
     /// Of these, `data` and `errors` must not co-exist.
@@ -480,7 +478,7 @@ impl Relationship {
     }
 }
 
-/// Top-level (Document) JSON-API specification violations
+/// Enum to describe top-level JSON:API specification violations
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum DocumentValidationError {
     IncludedWithoutData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,12 +57,12 @@
 //! let resource = example_flea.to_jsonapi_resource();
 //! ```
 //!
-//! ### Deserializing a JSONAPI Document
+//! ### Deserializing a JSON:API Document
 //!
-//! Deserialize a JSONAPI document using [serde] by explicitly declaring the
+//! Deserialize a JSON:API document using [serde] by explicitly declaring the
 //! variable type in `Result`
 //!
-//! ```text
+//! ```rust
 //! let serialized = r#"
 //! {
 //!   "data": [{
@@ -95,14 +95,14 @@
 //! Or parse the `String` directly using the
 //! [Resource::from_str](api/struct.Resource.html) trait implementation
 //!
-//! ```text
+//! ```rust
 //! let data = Resource::from_str(&serialized);
 //! assert_eq!(data.is_ok(), true);
 //! ```
 //!
 //! [`JsonApiDocument`][JsonApiDocument] implements `PartialEq` which allows two
 //! documents to be compared for equality. If two documents possess the **same
-//! contents** the ordering of the attributes and fields within the JSONAPI
+//! contents** the ordering of the attributes and fields within the JSON:API
 //! document are irrelevant and their equality will be `true`.
 //!
 //! ## Testing

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,11 +38,11 @@ where
     }
 
     /// Create a single resource object or collection of resource
-    /// objects directly from a
-    /// [`JsonApiDocument`](../api/struct.JsonApiDocument.html). This method
+    /// objects directly from 
+    /// [`DocumentData`](../api/struct.DocumentData.html). This method
     /// will parse the document (the `data` and `included` resources) in an
     /// attempt to instantiate the calling struct.
-    fn from_jsonapi_document(doc: &JsonApiDocument) -> Result<Self> {
+    fn from_jsonapi_document(doc: &DocumentData) -> Result<Self> {
         match doc.data.as_ref() {
             Some(primary_data) => {
                 match *primary_data {
@@ -88,11 +88,13 @@ where
     /// [`JsonApiDocument`](../api/struct.JsonApiDocument.html)
     fn to_jsonapi_document(&self) -> JsonApiDocument {
         let (resource, included) = self.to_jsonapi_resource();
-        JsonApiDocument {
-            data: Some(PrimaryData::Single(Box::new(resource))),
-            included,
-            ..Default::default()
-        }
+        JsonApiDocument::Data (
+            DocumentData {
+                data: Some(PrimaryData::Single(Box::new(resource))),
+                included,
+                ..Default::default()
+            }
+        )
     }
 
 
@@ -303,11 +305,13 @@ pub fn vec_to_jsonapi_resources<T: JsonApiModel>(
 /// ```
 pub fn vec_to_jsonapi_document<T: JsonApiModel>(objects: Vec<T>) -> JsonApiDocument {
     let (resources, included) = vec_to_jsonapi_resources(objects);
-    JsonApiDocument {
-        data: Some(PrimaryData::Multiple(resources)),
-        included,
-        ..Default::default()
-    }
+    JsonApiDocument::Data (
+        DocumentData {
+            data: Some(PrimaryData::Multiple(resources)),
+            included,
+            ..Default::default()
+        }
+    )
 }
 
 impl<M: JsonApiModel> JsonApiModel for Box<M> {


### PR DESCRIPTION
# Overview

This largely addresses the comments in #24 - it converts the top-level `JsonApiDocument` from a `struct` into an `enum` which then uses two new `struct` types (`DocumentError` and `DocumentData`) to handle JSON:API specification validation.

This change allows us to leverage Rust's type system to handle some of the primitive validations and assertions against the v1.0 specification instead of having to write validators to check for illegal combinations of `error` and `data`. Although this doesn't completely address those conditions - it does at least address the main separation between an "error" document and one which contains data.

Note that this is a breaking change to backwards API compatibility - largely because `JsonApiDocument` is now an `enum`.

This PR also includes a few documentation updates.

# Testing

This PR updates all existing tests and modifies them to use the new APIs for creating and validating JSON:API documents which contain `data` and `errors`.