### PR TITLE
build(deps): Update queryst to 3.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 serde = "^1.0.21"
 serde_json = "^1.0.6"
 serde_derive = "^1.0.21"
-queryst = "2"
+queryst = "3"
 log = "0.4"
 error-chain = "^0.12.0"
 


### PR DESCRIPTION
This resolves security advisories for the regex and thread_local crates, for which queryst 2.x relied on vulnerable versions.

regex: https://github.com/advisories/GHSA-m5pq-gvj9-9vr8
thread_local: https://github.com/advisories/GHSA-9hpw-r23r-xgm5